### PR TITLE
Fix issue #3

### DIFF
--- a/lib/RequestSignatureHelper.js
+++ b/lib/RequestSignatureHelper.js
@@ -66,14 +66,10 @@ RSH.prototype.generateTimestamp = function() {
 };
 
 /**
- * The following characters must not be escaped according to
- * RFC 3986: /^A-Za-z0-9\-_.~/
- * The standard JS escape function does the following wrong:
- * Should escepe: "*+"
- * Shouldn't escape: "~"
+ * Port of PHP rawurlencode().
  */
 RSH.prototype.escape = function(x) {
-    return escape(x).replace(/%7E/g, '~').replace(/\*/g, '%2A').replace(/\+/g, '%2B');
+    return encodeURIComponent(x).replace(/!/g, '%21').replace(/'/g, '%27').replace(/\(/g, '%28').replace(/\)/g, '%29').replace(/\*/g, '%2A');
 };
 
 RSH.prototype.digest = function(x) {


### PR DESCRIPTION
We need to use a JS port of PHP rawurlencode() function to encode parameters to support multibyte character strings.
It should now work on Latin diacritics as well.
