### PR TITLE
Removing setting params[RSH.kAWSAccessKeyId] in sign() as already set in 

### DIFF
--- a/lib/RequestSignatureHelper.js
+++ b/lib/RequestSignatureHelper.js
@@ -29,7 +29,6 @@ RSH.prototype.init = function(params) {
 
 RSH.prototype.sign = function(params) {
     // append params
-    params[RSH.kAWSAccessKeyId] = this[RSH.kAWSAccessKeyId];
     params[RSH.kTimestampParam] = this.generateTimestamp();
 
     // generate signature


### PR DESCRIPTION
Removing setting params[RSH.kAWSAccessKeyId] in sign() as already set in OperationHelper.prototype.generateParams()
