### PR TITLE
Require New `xml2js` Version which doesn't mess with `Object.prototype`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 , "main" : "./lib/apac"
 , "dependencies" :
   { "vows" : ">=0.5.0"
-  , "xml2js" : "*"
+  , "xml2js" : ">=0.1.7"
   }
 , "engines" : { "node" : ">=0.1.97" }
 , "licenses" :


### PR DESCRIPTION
See https://github.com/Leonidas-from-XIV/node-xml2js/issues/13

Cheers,
Daniel

/cc @aseemk

_P.S. Nice work on the library._
