### PR TITLE
Fix 'sys' deprecation warning on Node 0.6+.

### DIFF
--- a/lib/RequestSignatureHelper.js
+++ b/lib/RequestSignatureHelper.js
@@ -1,5 +1,4 @@
-var crypto = require('crypto'),
-    sys = require('sys');
+var crypto = require('crypto');
 
 var RSH = function(params) {
     this.init(params);


### PR DESCRIPTION
The code was requiring it, but it wasn't even being used.
