### PR TITLE
Added solaris as supported platform to install on nodejitsu

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "linux",
     "darwin",
     "freebsd",
-    "windows"
+    "windows",
+    "solaris"
   ],
   "directories": {
     "lib": "./lib/"


### PR DESCRIPTION
Here is the error message when deploying app to nodejitsu

npm http 200 http://nj-npm.irisnpm.com/apac/-/apac-0.0.11.tgz
npm ERR! notsup Unsupported
npm ERR! notsup Not compatible with your operating system or architecture: apac@0.0.11
npm ERR! notsup Valid OS:    linux,darwin,freebsd
npm ERR! notsup Valid Arch:  any
npm ERR! notsup Actual OS:   solaris
npm ERR! notsup Actual Arch: x64

npm ERR! System SunOS 5.11
npm ERR! command "/opt/local/bin/node" "/opt/local/bin/npm" "install"
npm ERR! cwd /root/tmp/tmp-18392ti1q2ts/build/package
npm ERR! node -v v0.8.8
npm ERR! npm -v 1.1.59
npm ERR! code EBADPLATFORM

I've updated package.json to workaround the problem.
I''ve confirmed that I can deploy app to nodejitsu.
But no other test has been done
