### PR TITLE
Add sunos for nodejitsu deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "freebsd",
     "windows",
     "solaris",
-    "win32"
+    "win32",
+    "sunos"
   ],
   "directories": {
     "lib": "./lib/"


### PR DESCRIPTION
Nodejitsu throws an error when I'm trying to deploy an application that has dependency on apac.

npm ERR! notsup Unsupported
npm ERR! notsup Not compatible with your operating system or architecture: apac@0.0.11
npm ERR! notsup Valid OS:    linux,darwin,freebsd
npm ERR! notsup Valid Arch:  any
npm ERR! notsup Actual OS:   sunos
npm ERR! notsup Actual Arch: x64

npm ERR! System SunOS 5.11
npm ERR! command "node" "/opt/local/bin/npm" "install"
npm ERR! cwd /root/tmp/tmp-143327lkozxs/build/package
npm ERR! node -v v0.8.22
npm ERR! npm -v 1.2.15
npm ERR! code EBADPLATFORM
