### PR TITLE
Removing OS dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apac",
   "description": "Amazon Product Advertising API Client for Node",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "author": "Dustin McQuay <dmcquay@gmail.com>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
As far as I can tell there are no OS dependent components being used (please correct me if I'm wrong).

The current npm module is only checking for the first 3 OS's in the list: linux, darwin, and freebsd, which leads me to believe that the module is out of date.

As I'm relatively new to the node.js world I'm not sure if a version bump is sufficient or if a npm publish command is also needed to update the module.

See the thread here: https://github.com/dmcquay/node-apac/issues/27 on why the install wasn't working on Windows (it looks like 2 subsequent modules have been made to circumvent the issue: cyber-apac and json-apac).
