### PR TITLE
Added optional callback to handle errors

### DIFF
--- a/lib/OperationHelper.js
+++ b/lib/OperationHelper.js
@@ -56,9 +56,10 @@ OperationHelper.prototype.generateUri = function(operation, params) {
     return uri;
 }
 
-OperationHelper.prototype.execute = function(operation, params, callback) {
+OperationHelper.prototype.execute = function(operation, params, callback, onError) {
     if (typeof(operation) === 'undefined') { throw 'Missing operation parameter' }
     if (typeof(params) === 'undefined') { params = {} }
+    if (typeof(onError) === 'undefined') { onError = function(err){ console.log(err.message)}; }
     var uri = this.generateUri(operation, params);
     var host = this.endPoint;
 
@@ -79,7 +80,7 @@ OperationHelper.prototype.execute = function(operation, params, callback) {
 
         response.on('end', function() {
             xml2js.parseString(responseBody, function(err, result){
-                if (err) {console.log(err);}
+                if (err) {onError(err);}
                 callback(result);
             });
         });
@@ -87,7 +88,7 @@ OperationHelper.prototype.execute = function(operation, params, callback) {
     });
 
     request.on('error', function (err) {
-        console.log(err.message);
+        onError(err.message);
     });
 
     request.end();


### PR DESCRIPTION
Required to be able to cleanly end outstanding requests in Node if an underlying service barfs.

The change relies on a new, optional fourth parameter and shouldn't break anything at all.
