### PR TITLE
Error objects instead of strings

### DIFF
--- a/lib/OperationHelper.js
+++ b/lib/OperationHelper.js
@@ -15,9 +15,9 @@ OperationHelper.prototype.init = function(params) {
     params = params || {};
 
     // check requried params
-    if (typeof(params.awsId)     === 'undefined') { throw 'Missing AWS Id param' }
-    if (typeof(params.awsSecret) === 'undefined') { throw 'Missing AWS Secret param' }
-    if (typeof(params.assocId)   === 'undefined') { throw 'Missing Associate Id param' }
+    if (typeof(params.awsId)     === 'undefined') { throw new Error('Missing AWS Id param') }
+    if (typeof(params.awsSecret) === 'undefined') { throw new Error('Missing AWS Secret param') }
+    if (typeof(params.assocId)   === 'undefined') { throw new Error('Missing Associate Id param') }
 
     // set instance variables from params
     this.awsId     = params.awsId;
@@ -61,7 +61,7 @@ OperationHelper.prototype.generateUri = function(operation, params) {
 }
 
 OperationHelper.prototype.execute = function(operation, params, callback) {
-    if (typeof(operation) === 'undefined') { throw 'Missing operation parameter' }
+    if (typeof(operation) === 'undefined') { throw new Error('Missing operation parameter') }
     if (typeof(params) === 'undefined') { params = {} }
 
     var uri = this.generateUri(operation, params);

--- a/lib/RequestSignatureHelper.js
+++ b/lib/RequestSignatureHelper.js
@@ -14,9 +14,9 @@ RSH.kSignatureParam = 'Signature';
 
 RSH.prototype.init = function(params) {
   // enforce required params
-  if (typeof(params[RSH.kAWSAccessKeyId]) === 'undefined') { throw 'Need access key id argument' }
-  if (typeof(params[RSH.kAWSSecretKey]) === 'undefined') { throw 'Need secret key argument' }
-  if (typeof(params[RSH.kEndPoint]) === 'undefined') { throw 'Need end point argument' }
+  if (typeof(params[RSH.kAWSAccessKeyId]) === 'undefined') { throw new Error('Need access key id argument') }
+  if (typeof(params[RSH.kAWSSecretKey]) === 'undefined') { throw new Error('Need secret key argument') }
+  if (typeof(params[RSH.kEndPoint]) === 'undefined') { throw new Error('Need end point argument') }
 
   // set params
   this[RSH.kAWSAccessKeyId] = params[RSH.kAWSAccessKeyId];


### PR DESCRIPTION
Due to the fact that some devtools rely on Error objects when logging,
it is not recomended to throw primitives like strings. Instead, throw an
Error object.