### PR TITLE
can now change endpoint after initialization

### DIFF
--- a/lib/OperationHelper.js
+++ b/lib/OperationHelper.js
@@ -11,8 +11,44 @@ OperationHelper.service = 'AWSECommerceService';
 OperationHelper.defaultEndPoint = 'ecs.amazonaws.com';
 OperationHelper.defaultBaseUri = '/onca/xml';
 
+/**
+ * Set instance
+ *
+ * ####Example:
+ *
+ *     opHelper.set('endPoint', 'webservices.amazon.de')
+ *
+ * @param {String} key
+ * @param {String} value
+ * @api public
+ */
+
+OperationHelper.prototype.set = function(key, value) {
+    if (arguments.length === 1) {
+        return this._options[key];
+    }
+    this._options[key] = value;
+    return value;
+};
+
+
+/**
+ * Gets instance
+ *
+ * ####Example:
+ *
+ *     opHelper.get('endPoint')
+ *
+ * @param {String} key
+ * @method get
+ * @api public
+ */
+
+OperationHelper.prototype.get = OperationHelper.prototype.set;
+
 OperationHelper.prototype.init = function(params) {
     params = params || {};
+    this._options = {};
 
     // check requried params
     if (typeof(params.awsId)     === 'undefined') { throw new Error('Missing AWS Id param') }
@@ -31,12 +67,13 @@ OperationHelper.prototype.init = function(params) {
     if (typeof(params.version) === 'string') OperationHelper.version = params.version;
 };
 
+
 OperationHelper.prototype.getSignatureHelper = function() {
-    if (typeof(this.signatureHelper) === 'undefined') {
+    if (typeof(this.signatureHelper) === 'undefined' || (this.get('endPoint') !== this.endPoint)) {
         var params = {};
         params[RSH.kAWSAccessKeyId] = this.awsId;
         params[RSH.kAWSSecretKey]   = this.awsSecret;
-        params[RSH.kEndPoint]       = this.endPoint;
+        params[RSH.kEndPoint]       = this.get('endPoint') || this.endPoint;
         this.signatureHelper = new RSH(params);
     }
     return this.signatureHelper;
@@ -65,11 +102,10 @@ OperationHelper.prototype.execute = function(operation, params, callback) {
     if (typeof(params) === 'undefined') { params = {} }
 
     var uri = this.generateUri(operation, params);
-    var host = this.endPoint;
     var xml2jsOptions = this.xml2jsOptions;
 
     var options = {
-        hostname: host,
+        hostname: this.get('endPoint') || this.endPoint,
         path: uri,
         method: 'GET'
     };
@@ -78,7 +114,7 @@ OperationHelper.prototype.execute = function(operation, params, callback) {
 
     var request = http.request(options, function (response) {
         response.setEncoding('utf8');
-        
+
         response.on('data', function (chunk) {
             responseBody += chunk;
         });


### PR DESCRIPTION
#54 

This addresses the changed end-point after initialization. It stores the original and assignable end-point, when the assignable end-point has been set the assigned end-point is used.

I have been running this on our production system for a few days and it works fine. You may want to consider adding this.

