### PR TITLE
allow overriding the http request scheme

### DIFF
--- a/lib/operation-helper.js
+++ b/lib/operation-helper.js
@@ -31,6 +31,7 @@ class OperationHelper {
         this.awsSecret = params.awsSecret
         this.assocId = params.assocId
         this.endPoint = params.endPoint || locale.getEndpointForLocale(params.locale)
+        this.scheme = params.scheme
         this.baseUri = params.baseUri || OperationHelper.defaultBaseUri
         this.xml2jsOptions = Object.assign({}, defaultXml2JsOptions, params.xml2jsOptions)
         this.throttler = new Throttler(params.maxRequestsPerSecond)
@@ -82,6 +83,7 @@ class OperationHelper {
 
         var uri = this.generateUri(operation, params)
         var host = this.endPoint
+        var scheme = this.scheme
         var xml2jsOptions = this.xml2jsOptions
 
         var options = {
@@ -89,6 +91,8 @@ class OperationHelper {
             path: uri,
             method: 'GET'
         }
+
+        if (scheme) options['scheme'] = scheme;
 
         var responseBody = ''
 

--- a/lib/operation-helper.specs.js
+++ b/lib/operation-helper.specs.js
@@ -44,6 +44,13 @@ describe('OperationHelper', function () {
             }))
             expect(opHelper.endPoint).to.equal('test.endpoint.com')
         })
+
+        it('sets scheme directly', () => {
+            let opHelper = new OperationHelper(Object.assign({}, baseParams, {
+                scheme: 'http'
+            }))
+            expect(opHelper.scheme).to.equal('http')
+        })
     })
 
     describe('#getSignatureHelper', () => {

--- a/lib/operation-helper.specs.js
+++ b/lib/operation-helper.specs.js
@@ -162,6 +162,7 @@ describe('OperationHelper', function () {
                     awsId: 'testAwsId',
                     awsSecret: 'testAwsSecret',
                     assocId: 'testAssocId',
+                    scheme: 'http',
                     xml2jsOptions
                 })
 
@@ -191,7 +192,8 @@ describe('OperationHelper', function () {
                     expect(http.request.firstCall.args[0]).to.eql({
                         hostname: locale.DEFAULT_ENDPOINT,
                         method: 'GET',
-                        path: 'testUri'
+                        path: 'testUri',
+                        scheme: 'http'
                     })
                 })
 


### PR DESCRIPTION
Added a simple way to override the default "scheme" property of the http request. When using apac in a desktop application such as Electron, all http requests are attempted with the 'file://" scheme by default—this provides a way to force the requests to go through via http or https