### PR TITLE
Use only https to make requests

### DIFF
--- a/lib/operation-helper.js
+++ b/lib/operation-helper.js
@@ -4,7 +4,7 @@ const RSH = require('./request-signature-helper').RequestSignatureHelper
 const Throttler = require('./throttler')
 const locale = require('./locale')
 
-const http = require('http')
+const https = require('https')
 const xml2js = require('xml2js')
 
 const defaultXml2JsOptions = {
@@ -31,7 +31,6 @@ class OperationHelper {
         this.awsSecret = params.awsSecret
         this.assocId = params.assocId
         this.endPoint = params.endPoint || locale.getEndpointForLocale(params.locale)
-        this.scheme = params.scheme
         this.baseUri = params.baseUri || OperationHelper.defaultBaseUri
         this.xml2jsOptions = Object.assign({}, defaultXml2JsOptions, params.xml2jsOptions)
         this.throttler = new Throttler(params.maxRequestsPerSecond)
@@ -87,7 +86,6 @@ class OperationHelper {
 
         var uri = this.generateUri(operation, params)
         var host = this.endPoint
-        var scheme = this.scheme
         var xml2jsOptions = this.xml2jsOptions
 
         var options = {
@@ -96,12 +94,10 @@ class OperationHelper {
             method: 'GET'
         }
 
-        if (scheme) options['scheme'] = scheme;
-
         var responseBody = ''
 
         const promise = new Promise((resolve, reject) => {
-            var request = http.request(options, function (response) {
+            var request = https.request(options, function (response) {
                 response.setEncoding('utf8')
 
                 response.on('data', function (chunk) {

--- a/lib/operation-helper.specs.js
+++ b/lib/operation-helper.specs.js
@@ -1,6 +1,6 @@
 "use strict"
 
-const http = require('http')
+const https = require('https')
 const EventEmitter = require('events')
 const xml2js = require('xml2js')
 const proxyquire = require('proxyquire')
@@ -43,13 +43,6 @@ describe('OperationHelper', function () {
                 endPoint: 'test.endpoint.com'
             }))
             expect(opHelper.endPoint).to.equal('test.endpoint.com')
-        })
-
-        it('sets scheme directly', () => {
-            let opHelper = new OperationHelper(Object.assign({}, baseParams, {
-                scheme: 'http'
-            }))
-            expect(opHelper.scheme).to.equal('http')
         })
     })
 
@@ -162,7 +155,6 @@ describe('OperationHelper', function () {
                     awsId: 'testAwsId',
                     awsSecret: 'testAwsSecret',
                     assocId: 'testAssocId',
-                    scheme: 'http',
                     xml2jsOptions
                 })
 
@@ -176,24 +168,23 @@ describe('OperationHelper', function () {
                     responseMock.emit('end')
                 }
 
-                sinon.stub(http, 'request').returns(requestMock).callsArgWith(1, responseMock)
+                sinon.stub(https, 'request').returns(requestMock).callsArgWith(1, responseMock)
                 sinon.stub(opHelper, 'generateUri').returns('testUri')
                 sinon.spy(xml2js, 'parseString')
             })
 
             afterEach(() => {
-                http.request.restore()
+                https.request.restore()
                 xml2js.parseString.restore()
             })
 
             const doAssertions = () => {
-                it('should creqte an http request with the correct options', () => {
-                    expect(http.request.callCount).to.equal(1)
-                    expect(http.request.firstCall.args[0]).to.eql({
+                it('should create an https request with the correct options', () => {
+                    expect(https.request.callCount).to.equal(1)
+                    expect(https.request.firstCall.args[0]).to.eql({
                         hostname: locale.DEFAULT_ENDPOINT,
                         method: 'GET',
                         path: 'testUri',
-                        scheme: 'http'
                     })
                 })
 
@@ -271,12 +262,12 @@ describe('OperationHelper', function () {
                     requestMock.emit('error', error)
                 }
 
-                sinon.stub(http, 'request').returns(requestMock).callsArgWith(1, responseMock)
+                sinon.stub(https, 'request').returns(requestMock).callsArgWith(1, responseMock)
                 sinon.stub(opHelper, 'generateUri').returns('testUri')
             })
 
             afterEach(() => {
-                http.request.restore()
+                https.request.restore()
             })
 
             context('(traditional callback)', () => {
@@ -334,13 +325,13 @@ describe('OperationHelper', function () {
                     responseMock.emit('end')
                 }
 
-                sinon.stub(http, 'request').returns(requestMock).callsArgWith(1, responseMock)
+                sinon.stub(https, 'request').returns(requestMock).callsArgWith(1, responseMock)
                 sinon.stub(opHelper, 'generateUri').returns('testUri')
                 sinon.stub(xml2js, 'parseString').callsArgWith(2, testError)
             })
 
             afterEach(() => {
-                http.request.restore()
+                https.request.restore()
                 xml2js.parseString.restore()
             })
 
@@ -402,13 +393,13 @@ describe('OperationHelper', function () {
                     }
                 }
 
-                sinon.stub(http, 'request')
+                sinon.stub(https, 'request')
                 const reqRes1 = buildReqAndResp()
                 const reqRes2 = buildReqAndResp()
                 const reqRes3 = buildReqAndResp()
-                http.request.onFirstCall().callsArgWith(1, reqRes1.res).returns(reqRes1.req)
-                http.request.onSecondCall().callsArgWith(1, reqRes2.res).returns(reqRes2.req)
-                http.request.onThirdCall().callsArgWith(1, reqRes3.res).returns(reqRes3.req)
+                https.request.onFirstCall().callsArgWith(1, reqRes1.res).returns(reqRes1.req)
+                https.request.onSecondCall().callsArgWith(1, reqRes2.res).returns(reqRes2.req)
+                https.request.onThirdCall().callsArgWith(1, reqRes3.res).returns(reqRes3.req)
 
                 sinon.stub(opHelper, 'generateUri').returns('testUri')
 
@@ -428,7 +419,7 @@ describe('OperationHelper', function () {
             })
 
             afterEach(() => {
-                http.request.restore()
+                https.request.restore()
             })
 
             it('should take at least (1 / maxRequestsPerSecond) * (numOperations - 1) seconds to complete', () => {


### PR DESCRIPTION
Hi, it seems like current implementation doesn't support https as it supposed to.

Even when I configure `scheme: "https"`, `http.request` sends the http request on port 80 anyways.
There are two different modules: `http` is for encrypted requests (on port 80) and `https` is for encrypted ones (port 443).

I do believe `https` only will cover all the possible use-cases including webpage loaded with `http` schema and electron apps and there is not need to keep configurable. So, it shouldn't break any existing apps with previous version of `node-apac`. Am I miss anything?

@dmcquay Would you consider merging this and releasing new package version?